### PR TITLE
Change datomic-free deps version

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -30,4 +30,4 @@
   {:extra-deps {com.datomic/client-cloud {:mvn/version "1.0.120"}}}
 
   :datomic-free
-  {:extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5703.21"}}}}}
+  {:extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5697"}}}}}


### PR DESCRIPTION
`datomic-free 0.9.5703.21` can not be downloaded from maven. 
I change it to `0.9.5697`

[Ref](https://mvnrepository.com/artifact/com.datomic/datomic-free)

