### PR TITLE
change deps.edn

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -2,7 +2,9 @@
 
  :deps
  {org.clojure/clojure {:mvn/version "1.11.1"}
-  com.cnuernber/charred {:mvn/version "1.011"}}
+  com.cnuernber/charred {:mvn/version "1.011"}
+  com.github.seancorfield/next.jdbc {:mvn/version "1.2.780"}
+  com.github.seancorfield/honeysql {:mvn/version "2.2.891"}}
 
  :mvn/repos
  {"my.datomic.com" {:url "https://my.datomic.com/repo"}}
@@ -16,10 +18,6 @@
   :test
   {:extra-paths ["test"]
    :extra-deps  {lambdaisland/kaocha {:mvn/version "1.68.1059"}}}
-
-  :jdbc
-  {:extra-deps {com.github.seancorfield/next.jdbc {:mvn/version "1.2.780"}
-                com.github.seancorfield/honeysql {:mvn/version "2.2.891"}}}
 
   :postgresql
   {:extra-deps {;; org.postgresql/postgresql {:mvn/version "42.4.0"}      ; "classic" pg jdbc driver


### PR DESCRIPTION
1. The plenish.clj use `udpate-vals` which requires clojure 1.11, so I add clojure version explicitly.
2. The plenish.clj use honeySQL and jdbc, so I add honeysql and jdbc into necessary dependencies. 
