### PR TITLE
Fix updates and retractions

### DIFF
--- a/bin/kaocha
+++ b/bin/kaocha
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-exec clojure -M:test:dev:jdbc:postgresql:datomic-free -m kaocha.runner "$@"
+exec clojure -M:test:dev:postgresql:datomic-free -m kaocha.runner "$@"


### PR DESCRIPTION
This fixes two main cases

- a regular attribute gets updated
- handling of cardinality/many attributes

An update in datomic looks like this

```clj
#datom[17592186046685 140 "posted" 13194139535817 true]
#datom[17592186046685 140 "draft" 13194139535817 false]
```

If attribute 140 is a membership attribute, then this would result in us removing this entity from the table. For non-membership attributes this also would result in incorrect behavior. What we do now is ignore the `added? false` datom, since the `added? true` datom will overwrite the value.

For cardinality/many we were creating join tables with `db__id` being a primary key, but that's of course not correct, because then you can only have one associated value for a given entity. Instead we've replaced this with a unique index on `(db__id, attribute)`, and adjusted the insert/delete logic accordingly.