### PR TITLE
For the "transactions" table, insert rather than upsert

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ resources/public/ui
 .store
 out
 .#*
+deps.local.edn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,11 @@
 
 ## Added
 
-## Fixed
+- Added a `find-max-t` helper function, for picking up work where it was left off
 
 ## Changed
+
+- Throw when trying to reprocess an earlier transaction
 
 # 0.2.37 (2022-09-14 / 5b770a2)
 

--- a/deps.local.edn
+++ b/deps.local.edn
@@ -1,3 +1,0 @@
-{:paths ["test"]
- :launchpad/aliases [:dev :postgresql]
- }

--- a/repl_sessions/find_prev_tx.clj
+++ b/repl_sessions/find_prev_tx.clj
@@ -20,3 +20,17 @@
   (d/log conn)
   1000
   9010))
+
+;; Given we are currently processing a certain transaction (say t=1012), can we
+;; find the t value of the previous transaction? This could be useful to add an
+;; additional guarantee that transactions are processed exactly in order, by
+;; adding a postgresql trigger that validates that transactions form an unbroken
+;; chain.
+
+(let [max-t 1012
+      db (d/as-of (d/db conn) (dec max-t))]
+  (d/q '[:find (max ?t) .
+         :where
+         [?i :db/txInstant]
+         [(datomic.api/tx->t ?i) ?t]]
+       db))

--- a/tests.edn
+++ b/tests.edn
@@ -1,2 +1,3 @@
 #kaocha/v1
-{:plugins [:notifier :print-invocations :profiling]}
+{:plugins [:notifier :print-invocations :profiling]
+ :capture-output? false}


### PR DESCRIPTION
We generally always upsert, since that matches best the Datomic semantics, but transactions are never updated, so a simple INSERT will do, and it ensures that when importing a transaction twice that the process throws (the primary key constraint will be violated), which acts as a consistency guarantee (the caller can fetch the latest t value and retry.)

<!--

Thank you for your contribution! Please also think about (where applicable)

- the CHANGELOG, you can add an entry at the top underneath "Unreleased"
- the README and other documentation
- the tests, at least run them yourself before submitting (usually a `bin/kaocha` will do)

-->
