### PR TITLE
fix bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ the process.
 
       ;; grab the datomic transactions you want plenish to process. this grabs
       ;; all transactions that haven't been processed yet.
-      txs   (d/tx-range (d/log datomic-conn) (inc max-t) nil)]
+      txs   (d/tx-range (d/log datomic-conn) (when max-t (inc max-t)) nil)]
 
   ;; get to work
   (plenish/import-tx-range ctx datomic-conn pg-conn txs))

--- a/src/lambdaisland/plenish.clj
+++ b/src/lambdaisland/plenish.clj
@@ -607,7 +607,7 @@
 
         ;; Grab the datomic transactions you want Plenish to process. This grabs
         ;; all transactions that haven't been processed yet.
-        txs   (d/tx-range (d/log datomic-conn) (inc max-t) nil)]
+        txs   (d/tx-range (d/log datomic-conn) (when max-t (inc max-t)) nil)]
 
     ;; Get to work
     (import-tx-range ctx datomic-conn pg-conn txs)))


### PR DESCRIPTION
It is possible that the value of `max-t` is nil, and when it is nil, `(inc max-t)` will throw exception. 