### PR TITLE
Freely available deps.

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -6,9 +6,6 @@
   com.github.seancorfield/next.jdbc {:mvn/version "1.3.874"}
   com.github.seancorfield/honeysql {:mvn/version "2.4.1026"}}
 
- :mvn/repos
- {"my.datomic.com" {:url "https://my.datomic.com/repo"}}
-
  :aliases
  {:dev
   {:extra-paths ["dev"]
@@ -25,10 +22,10 @@
                 }}
 
   :datomic-pro
-  {:extra-deps {com.datomic/datomic-pro {:mvn/version "1.0.6202"}}}
+  {:extra-deps {com.datomic/peer {:mvn/version "1.0.6726"}}}
 
   :datomic-cloud
   {:extra-deps {com.datomic/client-cloud {:mvn/version "1.0.123"}}}
 
   :datomic-free
-  {:extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5703.21"}}}}}
+  {:extra-deps  {com.datomic/datomic-free {:mvn/version "0.9.5697"}}}}}


### PR DESCRIPTION
Current deps require being a Datomic customer to get the peer library and the specified version of datomic-free.

Use the now freely available `com.datomic/peer` dependency for pro. This is untested as I don't have a Datomic pro system right now.

Also move to the last version of `com.datomic/datomic-free` available in Maven central. I've verified that the tests pass with this version.